### PR TITLE
Return max block limit in error response

### DIFF
--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -442,7 +442,9 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 		}
 
 		if !s.isAllowedBlockRange(parsedReq) {
-			responses[i] = NewRPCErrorRes(parsedReq.ID, errors.New("block range too large"))
+			responses[i] = NewRPCErrorRes(
+				parsedReq.ID,
+				fmt.Errorf("block range too large, max limit: %d", s.maxBlockRange))
 			continue
 		}
 


### PR DESCRIPTION
**Description**
Add the max block limit in the error response.
